### PR TITLE
refactor: blade.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "highlight.js syntax definition for Laravel's Blade template language",
   "main": "src/languages/blade.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/languages/blade.js
+++ b/src/languages/blade.js
@@ -3,100 +3,60 @@
  * and https://github.com/miken32/highlightjs-blade.
  */
 
-module.exports = function (hljs) {
-    const COMMENT = hljs.COMMENT(/\{\{--/, /--\}\}/);
+export default function (hljs) {
+    const COMMENT = hljs.COMMENT(/\{\{--/, /--}}/);
 
     // {{ $escapedTemplateVariable }}
     const ESCAPED_TEMPLATE_VARIABLE = {
-        className: 'template-variable',
-        begin: /\{\{/,
-        starts: {
-            end: /\}\}/,
-            returnEnd: true,
-            subLanguage: 'php',
-        },
-    };
-
-    // `}}` - just in case we're highlighting a partial file
-    const ESCAPED_TEMPLATE_VARIABLE_END = {
-        className: 'template-variable',
-        begin: /\}\}/,
-    };
-
-    // {{{ $likeThis }}}
-    const ESCAPED_TEMPLATE_VARIABLE_WITH_TRIPLE_CURLY_BRACKETS = {
-        className: 'template-variable',
-        begin: /\{\{\{/,
-        starts: {
-            end: /\}\}\}/,
-            returnEnd: true,
-            subLanguage: 'php',
-        },
-    };
-
-    // `}}}` - just in case we're highlighting a partial file
-    const ESCAPED_TEMPLATE_VARIABLE_WITH_TRIPLE_CURLY_BRACKETS_END = {
-        className: 'template-variable',
-        begin: /\}\}\}/,
+        begin: /(?<begin>\{\{)/,
+        beginScope: 'template-variable',
+        end: /(?<end>}})/,
+        endScope: 'template-variable',
+        subLanguage: 'php',
     };
 
     // {!! $hello !!}
     const UNESCAPED_TEMPLATE_VARIABLE = {
-        className: 'template-variable',
-        begin: /\{!!/,
-        starts: {
-            end: /!!\}/,
-            returnEnd: true,
-            subLanguage: 'php',
-        },
+        begin: /(?<begin>\{!!)/,
+        beginScope: 'template-variable',
+        end: /(?<end>!!})/,
+        endScope: 'template-variable',
+        subLanguage: 'php',
     }
-
-    const UNESCAPED_TEMPLATE_VARIABLE_END = {
-        className: 'template-variable',
-        begin: /!!\}/,
-    };
-
-    // @php($a = 2)
-    const SINGLE_LINE_PHP_DIRECTIVE = {
-        className: 'template-tag',
-        begin: /@php\(/,
-        starts: {
-            end: /\)/,
-            returnEnd: true,
-            subLanguage: 'php',
-        },
-        relevance: 15,
-    };
 
     // @php $a = 1 @endphp
     const MULTI_LINE_PHP_DIRECTIVE = {
-        className: 'template-tag',
-        begin: /@php/,
-        starts: {
-            end: /@endphp/,
-            returnEnd: true,
-            subLanguage: 'php',
-        },
-        relevance: 10,
+        begin: /(?<begin>@php)/,
+        beginScope: 'keyword',
+        end: /(?<end>@endphp)/,
+        endScope: 'keyword',
+        subLanguage: 'php',
     };
 
     // :blade-value="$phpVar"
     const BLADE_COMPONENT_ATTRIBUTE = {
-        className: 'attr',
-        begin: /:[\w-]+="/,
-        starts: {
-            end: /"(?=\s|\n|\/)/,
-            returnEnd: true,
-            subLanguage: 'php',
-        },
+        begin: /(?<=\s)(?<begin>:[\w-]+=")/,
+        excludeBegin: true,
+        end: /(?<end>")/,
+        excludeEnd: true,
+        subLanguage: 'php',
     };
 
     // @something
     const CATCH_ALL_DIRECTIVE = {
-        begin: /@\w+/,
-        end: /\W/,
+        scope: 'keyword',
+        match: /(?<match>@[a-zA-Z]+)/,
+    };
+
+    // @foreach ($list as $item)
+    // or
+    // @foreach($list as $item)
+    const STATEMENT_AFTER_BLADE_DIRECTIVES = {
+        begin: /(?<=@[a-zA-Z]+\s?)(?<begin>\()/,
+        excludeBegin: true,
+        end: /(?<end>\))/,
         excludeEnd: true,
-        className: 'template-tag',
+        subLanguage: 'php',
     };
 
     return {
@@ -106,15 +66,11 @@ module.exports = function (hljs) {
         contains: [
             COMMENT,
             ESCAPED_TEMPLATE_VARIABLE,
-            ESCAPED_TEMPLATE_VARIABLE_END,
-            ESCAPED_TEMPLATE_VARIABLE_WITH_TRIPLE_CURLY_BRACKETS,
-            ESCAPED_TEMPLATE_VARIABLE_WITH_TRIPLE_CURLY_BRACKETS_END,
             UNESCAPED_TEMPLATE_VARIABLE,
-            UNESCAPED_TEMPLATE_VARIABLE_END,
-            SINGLE_LINE_PHP_DIRECTIVE,
             MULTI_LINE_PHP_DIRECTIVE,
             BLADE_COMPONENT_ATTRIBUTE,
-            CATCH_ALL_DIRECTIVE
+            CATCH_ALL_DIRECTIVE,
+            STATEMENT_AFTER_BLADE_DIRECTIVES
         ],
     };
 }


### PR DESCRIPTION
Update regex rule for most of blade syntax.

- use es module
- update regex rule
- remove deprecated mode attribute `className`
- remove triple curly brackets
- remove single line php directive
- add `STATEMENT_AFTER_BLADE_DIRECTIVES` mode

Blade highlight preview

![image](https://github.com/user-attachments/assets/d2e95f1b-18ce-49a3-ac87-2e61d68b886a)